### PR TITLE
Migration errors in a separate window

### DIFF
--- a/src/controllers/SiteController.php
+++ b/src/controllers/SiteController.php
@@ -309,6 +309,24 @@ class SiteController extends ControllerRestrictedBase
     }
 
     /**
+     * @param $id
+     *
+     * @return string
+     *
+     * @throws HttpException
+     */
+    public function actionViewMigrationError($id): string
+    {
+        $model = ReleaseRequest::findByPk($id);
+        if (!$model) {
+            throw new HttpException(404, 'The requested page does not exist.');
+        }
+        return $this->render('viewMigrationError', array(
+            'model' => $model,
+        ));
+    }
+
+    /**
      * выход
      */
     public function actionLogout()

--- a/src/helpers/ReleaseRequest.php
+++ b/src/helpers/ReleaseRequest.php
@@ -1,0 +1,145 @@
+<?php
+declare(strict_types=1);
+
+namespace whotrades\rds\helpers;
+
+use Yii;
+use yii\bootstrap\BaseHtml;
+use yii\helpers\Url;
+use \whotrades\rds\models\ReleaseRequest as ReleaseRequestModel;
+
+class ReleaseRequest
+{
+
+    /**
+     * Returns array with 2 elements:
+     * - array of buttons
+     * - array of messages
+     *
+     * @param ReleaseRequestModel $releaseRequest
+     *
+     * @return array|array[]
+     */
+    public static function getButtonsAndMessages(ReleaseRequestModel $releaseRequest): array
+    {
+        $buttons = [];
+        $messages = [];
+
+        if ($releaseRequest->isDeleted()) {
+            $messages = [Yii::t('rds', 'release_deleted')];
+            return [$buttons, $messages];
+        }
+
+        if ($releaseRequest->showCronDiff()) {
+            /** @var $currentUsed ReleaseRequestModel */
+            $currentUsed = ReleaseRequestModel::find()->where(
+                [
+                    'rr_status' => ReleaseRequestModel::getUsedStatuses(),
+                    'rr_project_obj_id' => $releaseRequest->rr_project_obj_id,
+                ]
+            )->one();
+
+            if ($currentUsed && $currentUsed->getCronConfigCleaned() != $releaseRequest->getCronConfigCleaned()) {
+                $diffStat = Yii::$app->diffStat->getDiffStat($currentUsed->getCronConfigCleaned(), $releaseRequest->getCronConfigCleaned());
+                $diffStat = preg_replace('~\++~', '<span style="color: #32cd32">$0</span>', $diffStat);
+                $diffStat = preg_replace('~\-+~', '<span style="color: red">$0</span>', $diffStat);
+                $messages[] = Html::aTargetBlank(Url::to(['/diff/index/', 'id1' => $releaseRequest->obj_id, 'id2' => $currentUsed->obj_id]), Yii::t('rds', 'cron_changed')) . '<br />' . $diffStat;
+            }
+        }
+
+        if ($releaseRequest->showInstallationErrors()) {
+            $messages[] = Html::a(Yii::t('rds/errors', 'deploy_error'), '#', [
+                'style' => 'info',
+                'data' => ['toggle' => 'modal', 'target' => '#release-request-install-error-' . $releaseRequest->obj_id, 'onclick' => "return false;"],
+            ]);
+        }
+
+        if ($releaseRequest->showActivationErrors()) {
+            $messages[] = Html::a(Yii::t('rds/errors', 'activation_error'), '#', [
+                'style' => 'info',
+                'data' => ['toggle' => 'modal', 'target' => '#release-request-use-error-' . $releaseRequest->obj_id, 'onclick' => "return false;"],
+            ]);
+        }
+
+        if ($releaseRequest->canBeRecreated()) {
+            $buttons[] = Html::a(BaseHtml::icon('repeat') . ' ' . Yii::t('rds', 'btn_rebuild'), Url::to(['/site/recreate-release', 'id' => $releaseRequest->obj_id]), ['class' => 'ajax-url btn btn-default']);
+
+            if ($releaseRequest->rr_status === ReleaseRequestModel::STATUS_FAILED) {
+                return [$buttons, $messages];
+            }
+        }
+
+        if ($releaseRequest->shouldBeInstalled()) {
+            $buttons[] = Html::a(Yii::t('rds', 'btn_deploy'), Url::to(['/site/install-release', 'id' => $releaseRequest->obj_id]), ['class' => 'install-button btn btn-primary', 'data-id' => $releaseRequest->obj_id]);
+            return [$buttons, $messages];
+        }
+
+        if ($releaseRequest->shouldBeMigrated()) {
+            if ($releaseRequest->rr_migration_status == ReleaseRequestModel::MIGRATION_STATUS_UP) {
+                $messages[] = "Wrong migration status";
+                return [$buttons, $messages];
+            } elseif ($releaseRequest->rr_migration_status == ReleaseRequestModel::MIGRATION_STATUS_UPDATING) {
+                $messages[] = "Updating migrations...";
+                return [$buttons, $messages];
+            } elseif ($releaseRequest->rr_migration_status == ReleaseRequestModel::MIGRATION_STATUS_FAILED) {
+                $messages[] = "updating migrations failed";
+
+                $messages[] = Html::a('View error', '#', [
+                    'style' => 'info',
+                    'data' => ['toggle' => 'modal', 'target' => '#release-request-migration-error-' . $releaseRequest->obj_id, 'onclick' => "return false;"],
+                ]);
+
+                $buttons[] = Html::a('Retry migration', ['/use/migrate', 'id' => $releaseRequest->obj_id], ['class' => 'ajax-url btn btn-primary']);
+
+                return [$buttons, $messages];
+            } else {
+                $buttons[] = Html::a(Yii::t('rds', 'btn_run_pre_migrations'), Url::to(['/use/migrate', 'id' => $releaseRequest->obj_id]), ['class' => 'ajax-url btn btn-primary']);
+                $messages[] = Html::a(Yii::t('rds', 'btn_view_pre_migrations'), '#', ['onclick' => '$(\'#migrations-' . $releaseRequest->obj_id . '\').toggle(\'fast\'); return false;']);
+
+
+                $migrations = "<div id='migrations-{$releaseRequest->obj_id}' style='display: none'>";
+                // ag: @see whotrades\rds\models\MigrationBase::getNameForUrl()
+                $getNameForUrl = function ($migrationName) {
+                    return str_replace('\\', '/', $migrationName);
+                };
+                foreach (json_decode($releaseRequest->rr_new_migrations) as $migration) {
+                    $migrations .= Html::a($migration, $releaseRequest->project->getMigrationUrl($getNameForUrl($migration), \whotrades\rds\models\Migration::TYPE_PRE));
+                }
+                $migrations .= "</div>";
+                $messages[] = $migrations;
+
+                return [$buttons, $messages];
+            }
+        }
+
+        if ($releaseRequest->canBeUsed()) {
+            if ($releaseRequest->isChild()) {
+                $messages[] = 'It is a child';
+                return [$buttons, $messages];
+            }
+
+            $buttons[] = Html::a(Yii::t('rds', 'btn_activate_release'), Url::to(['/use/create', 'id' => $releaseRequest->obj_id]), ['class' => 'use-button btn btn-primary']);
+            return [$buttons, $messages];
+        }
+
+        if ($releaseRequest->canBeReverted()) {
+            if ($releaseRequest->isChild()) {
+                $messages[] = "Prev version is {$releaseRequest->rr_old_version}";
+                return [$buttons, $messages];
+            }
+
+            $buttons[] = Html::a(Yii::t('rds', 'btn_revert_release', ['version' => $releaseRequest->rr_old_version]), Url::to(['/use/revert', 'id' => $releaseRequest->obj_id]), ['class' => 'use-button btn btn-warning']);
+
+            return [$buttons, $messages];
+        }
+
+        if (!$releaseRequest->canBeUsedChildren()) {
+            $messages[] = 'Waiting for children...';
+
+            return [$buttons, $messages];
+        }
+
+        return [$buttons, $messages];
+    }
+
+}

--- a/src/helpers/ReleaseRequest.php
+++ b/src/helpers/ReleaseRequest.php
@@ -94,24 +94,20 @@ class ReleaseRequest
                 return [$buttons, $messages];
             } else {
                 $buttons[] = Html::a(Yii::t('rds', 'btn_run_pre_migrations'), Url::to(['/use/migrate', 'id' => $releaseRequest->obj_id]), ['class' => 'ajax-url btn btn-primary']);
-                $messages[] = Html::a(Yii::t('rds', 'btn_view_pre_migrations'), '#', ['onclick' => '$(\'#migrations-' . $releaseRequest->obj_id . '\').toggle(\'fast\'); return false;']);
-
-
-                $migrations = "<div id='migrations-{$releaseRequest->obj_id}' style='display: none'>";
-                // ag: @see whotrades\rds\models\MigrationBase::getNameForUrl()
-                $getNameForUrl = function ($migrationName) {
-                    return str_replace('\\', '/', $migrationName);
-                };
 
                 if (!empty($releaseRequest->rr_new_migrations)) {
+                    $migrations = Html::a(Yii::t('rds', 'btn_view_pre_migrations'), '#', ['onclick' => '$(\'#migrations-' . $releaseRequest->obj_id . '\').toggle(\'fast\'); return false;']);
+                    $migrations .= "<div id='migrations-{$releaseRequest->obj_id}' style='display: none'>";
+                    // ag: @see whotrades\rds\models\MigrationBase::getNameForUrl()
+                    $getNameForUrl = function ($migrationName) {
+                        return str_replace('\\', '/', $migrationName);
+                    };
                     foreach (json_decode($releaseRequest->rr_new_migrations) as $migration) {
                         $migrations .= Html::a($migration, $releaseRequest->project->getMigrationUrl($getNameForUrl($migration), \whotrades\rds\models\Migration::TYPE_PRE));
                     }
+                    $migrations .= "</div>";
+                    $messages[] = $migrations;
                 }
-
-                $migrations .= "</div>";
-                $messages[] = $migrations;
-
                 return [$buttons, $messages];
             }
         }

--- a/src/helpers/ReleaseRequest.php
+++ b/src/helpers/ReleaseRequest.php
@@ -74,7 +74,7 @@ class ReleaseRequest
             return [$buttons, $messages];
         }
 
-        if ($releaseRequest->shouldBeMigrated()) {
+        if (true || $releaseRequest->shouldBeMigrated()) {
             if ($releaseRequest->rr_migration_status == ReleaseRequestModel::MIGRATION_STATUS_UP) {
                 $messages[] = "Wrong migration status";
                 return [$buttons, $messages];
@@ -102,9 +102,13 @@ class ReleaseRequest
                 $getNameForUrl = function ($migrationName) {
                     return str_replace('\\', '/', $migrationName);
                 };
-                foreach (json_decode($releaseRequest->rr_new_migrations) as $migration) {
-                    $migrations .= Html::a($migration, $releaseRequest->project->getMigrationUrl($getNameForUrl($migration), \whotrades\rds\models\Migration::TYPE_PRE));
+
+                if (!empty($releaseRequest->rr_new_migrations)) {
+                    foreach (json_decode($releaseRequest->rr_new_migrations) as $migration) {
+                        $migrations .= Html::a($migration, $releaseRequest->project->getMigrationUrl($getNameForUrl($migration), \whotrades\rds\models\Migration::TYPE_PRE));
+                    }
                 }
+
                 $migrations .= "</div>";
                 $messages[] = $migrations;
 

--- a/src/translations/en-US/rds.php
+++ b/src/translations/en-US/rds.php
@@ -32,6 +32,7 @@ return [
     'head_project_create' => 'Create project',
     'head_build_with_params' => 'Build #{0} ({1})',
     'head_migrations_management' => 'Migrations management (PRE/POST)',
+    'head_release_request_migration_error' => 'Migration error for release request #{0}',
 
     // Buttons
     'btn_new' => 'New',
@@ -148,4 +149,5 @@ return [
     'hint_select_child_project' => 'Select child project ...',
     'hint_local_configuration_warning' => 'Warning! It\'s better to leave comment above changed line about who and why changed it.',
     'hint_select_servers' => 'Select servers ...',
+    'hint_open_in_a_new_window' => 'Open in a new window',
 ];

--- a/src/translations/ru-RU/rds.php
+++ b/src/translations/ru-RU/rds.php
@@ -37,6 +37,7 @@ return [
     'head_project_create' => 'Создать проект',
     'head_build_with_params' => 'Сборка #{0} ({1})',
     'head_migrations_management' => 'Управление PRE/POST миграциями',
+    'head_release_request_migration_error' => 'Ошибка миграции релиза #{0}',
 
     // Buttons
     'btn_new' => 'Создать',
@@ -151,4 +152,5 @@ return [
     'hint_select_child_project' => 'Выберите дочерний проект ...',
     'hint_local_configuration_warning' => 'Внимание! Редактируя настройки, желательно указать в комментариях над измененной строкой - причину и авторство. Пример: // dz: поменял то-то, потому-то @since 2017-01-01',
     'hint_select_servers' => 'Выберите серверы ...',
+    'hint_open_in_a_new_window' => 'Открыть в новом окне',
 ];

--- a/src/views/site/viewMigrationError.php
+++ b/src/views/site/viewMigrationError.php
@@ -1,0 +1,10 @@
+<?php
+/** @var $this View */
+use whotrades\rds\models\ReleaseRequest;
+use yii\web\View;
+
+/** @var $model ReleaseRequest */
+?>
+
+<h1><?=Yii::t('rds', 'head_release_request_migration_error', [$model->obj_id])?></h1>
+<pre><?=$model->rr_migration_error;?></pre>


### PR DESCRIPTION
- Added possibility to open migration errors in a separate window
- Release request action buttons and messages refactored