### PR TITLE
[+] added support monolog/monolog:^2.7 #WTT-13113

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "ext-pdo": "*",
         "ext-zmq": "*",
         "samdark/yii2-psr-log-target": "~1.1.3",
-        "monolog/monolog": "^1.2.5"
+        "monolog/monolog": "^1.2.5|^2.7"
     },
     "require-dev": {
         "yiisoft/yii2-debug": "2.0.9",


### PR DESCRIPTION
Добавлена поддержка логера `"monolog/monolog":"^2.7"`. Это необходимо, чтобы пакет поддерживался PHP8 в случае, если ставится пакет "whotrades/monolog-extensions" с поддержкой PHP8