### PR TITLE
[*] fix php8.0 errors #WTT-14484

### DIFF
--- a/src/components/DiffStat.php
+++ b/src/components/DiffStat.php
@@ -7,7 +7,7 @@ final class DiffStat extends \yii\base\BaseObject
     /**
      * @param string $text1
      * @param string $text2
-     * @return mixed|null
+     * @return mixed|string
      */
     public function getDiffStat($text1, $text2)
     {
@@ -25,7 +25,7 @@ final class DiffStat extends \yii\base\BaseObject
         if ($returnVar == 0) {
             return str_replace('unknown | ', '', reset($output));
         } else {
-            return null;
+            return '';
         }
     }
 }


### PR DESCRIPTION
Результат метода `\whotrades\rds\components\DiffStat::getDiffStat` передается в функцию `preg_replace` в аргумент `$subject`, который может быть или array или string. Т.к. сейчас возвращается null, то происходит ошибка.